### PR TITLE
Make Stocks/Portfolio cards go multi-column on wider screens

### DIFF
--- a/src/app/stocks/stocks-content/stocks-content.component.html
+++ b/src/app/stocks/stocks-content/stocks-content.component.html
@@ -177,7 +177,7 @@
 
       <!-- Available Stocks List -->
       <div class="stocks-list-scroll-container">
-        <div *ngIf="!isLoading && getFilteredBusinesses().length > 0">
+        <ng-container *ngIf="!isLoading && getFilteredBusinesses().length > 0">
           <div
             *ngFor="let business of getFilteredBusinesses(); trackBy: trackByFriendBusinessId"
             class="habit-business-item"
@@ -295,7 +295,7 @@
               </div>
             </div>
           </div>
-        </div>
+        </ng-container>
       </div>
 
       <!-- Empty State for Available Stocks -->
@@ -495,7 +495,7 @@
 
       <!-- Portfolio Holdings -->
       <div class="stocks-list-scroll-container">
-        <div *ngIf="!isLoading && portfolio.length > 0">
+        <ng-container *ngIf="!isLoading && portfolio.length > 0">
           <div *ngFor="let holding of portfolio" class="habit-business-item">
             <div class="item-content">
               <img
@@ -662,7 +662,7 @@
               </div>
             </div>
           </div>
-        </div>
+        </ng-container>
       </div>
 
       <!-- Empty State for Portfolio -->

--- a/src/app/stocks/stocks-content/stocks-content.component.scss
+++ b/src/app/stocks/stocks-content/stocks-content.component.scss
@@ -346,6 +346,30 @@
   padding-right: 4px;
 }
 
+// Multi-column card grid — mirrors the Home screen's .habit-businesses-container
+// breakpoints so Available Stocks / Portfolio cards go 2-up then 3-up as the
+// screen gets bigger instead of staying a single stacked column forever.
+@media (min-width: 768px) {
+  .stocks-list-scroll-container {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    align-items: start;
+    gap: 0 16px;
+
+    // Same reasoning as Home: without this a card's wide inline calendar
+    // can push its column past its fair 1fr share and desync the columns.
+    > .habit-business-item {
+      min-width: 0;
+    }
+  }
+}
+
+@media (min-width: 1024px) {
+  .stocks-list-scroll-container {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
 // Stocks sections - match homepage habit-businesses styling
 .my-habit-businesses {
   .section-header {
@@ -1292,15 +1316,19 @@
 }
 
 // Stack the price/actions sidebar under the calendar+chart column instead of
-// beside it for tablet-landscape/small-laptop widths (1025-1400px — this is
-// where an iPad Pro in landscape lands, e.g. 13" M4/M5 at 1376pt, 12.9" 6th
-// gen at 1366pt, 11" M4 at 1210pt). At these widths the row layout above
-// leaves the earnings-section sidebar sitting mostly empty next to the much
-// taller calendar+chart column in .business-info, since the card height is
-// dictated by that taller column. Reuses the same top-left icon overlay
-// pattern as the <1025px stacked layout below, just sized for the bigger
-// icon/fonts this range already uses (see block above).
-@media (min-width: 1025px) and (max-width: 1400px) {
+// beside it from tablet-landscape widths up (1025px+ — this is where an iPad
+// Pro in landscape lands, e.g. 13" M4/M5 at 1376pt, 12.9" 6th gen at 1366pt,
+// 11" M4 at 1210pt). At these widths the row layout above leaves the
+// earnings-section sidebar sitting mostly empty next to the much taller
+// calendar+chart column in .business-info, since the card height is dictated
+// by that taller column. No upper bound: from 768px up, cards sit in a
+// 2-or-3-column grid (see .stocks-list-scroll-container), so a card never
+// gets the full viewport width again — the row layout's implicit default
+// past 1400px would otherwise squeeze icon/info/earnings into a column-width
+// sliver instead of stacking. Reuses the same top-left icon overlay pattern
+// as the <1025px stacked layout below, just sized for the bigger icon/fonts
+// this range already uses (see block above).
+@media (min-width: 1025px) {
   .my-habit-businesses {
     .habit-business-item {
       .item-content {


### PR DESCRIPTION
## Summary
- Available Stocks and Portfolio holdings cards were a single stacked column at every screen size, unlike Home which goes 2/3-up as the viewport widens.
- `.stocks-list-scroll-container` now becomes a CSS grid at 768px+ (2 columns) and 1024px+ (3 columns), matching Home's `.habit-businesses-container` breakpoints.
- Swapped the `<div *ngIf>` wrapper around each card list's `*ngFor` for `<ng-container>` so cards sit directly under the grid container (matching how the loading skeleton is already structured).
- Extended the existing "stack icon/info/earnings vertically" card layout to apply at every width ≥1025px instead of capping at 1400px — cards no longer get the full viewport width once gridded, so the old cutoff would've left cards past 1400px squeezed into a cramped side-by-side row inside a narrow grid column.

Below 768px behavior is unchanged (single column).

## Test plan
- [x] `ng build` (development and ios configs) compiles clean, no new errors/warnings
- [ ] Visually confirm 2-up layout at ~768-1023px and 3-up at 1024px+ in a browser (not verified here — this session only has access to an iOS Simulator, which is narrower than 768px)

---
_Generated by [Claude Code](https://claude.ai/code/session_014z9vCQX12VoZ4cPosdEr7j)_