### PR TITLE
fix: block direct client updates to cash/net_worth via RLS WITH CHECK

### DIFF
--- a/supabase/migrations/20260821000000_lock_down_cash_net_worth_rls.sql
+++ b/supabase/migrations/20260821000000_lock_down_cash_net_worth_rls.sql
@@ -1,0 +1,29 @@
+-- Lock down direct client updates to cash and net_worth columns.
+--
+-- The existing UPDATE policy on user_profiles only checks row ownership
+-- (auth.uid() = id) with no column restriction. Any authenticated user
+-- can bypass the app and set arbitrary cash/net_worth values via the
+-- Supabase JS client (e.g. from devtools).
+--
+-- All legitimate cash/net_worth mutations already go through SECURITY
+-- DEFINER RPCs (purchase_stock_shares, dividends, etc.) that bypass
+-- RLS entirely, so blocking these columns in the direct UPDATE policy
+-- does not affect normal operation.
+--
+-- Related: update_username() migration (20260813010000) applied the
+-- same pattern for the name column.
+
+-- Replace the unrestricted UPDATE policy with one that blocks cash/net_worth.
+DROP POLICY IF EXISTS "Users can update own profile" ON user_profiles;
+
+CREATE POLICY "Users can update own profile" ON user_profiles
+  FOR UPDATE
+  USING (auth.uid() = id)
+  WITH CHECK (
+    auth.uid() = id
+    AND cash IS NOT DISTINCT FROM OLD.cash
+    AND net_worth IS NOT DISTINCT FROM OLD.net_worth
+  );
+
+COMMENT ON POLICY "Users can update own profile" ON user_profiles
+  IS 'Allows users to update their own profile, but blocks direct changes to cash and net_worth. Those columns must only be modified through SECURITY DEFINER RPCs.';

--- a/supabase/verify_cash_rls_fix.sql
+++ b/supabase/verify_cash_rls_fix.sql
@@ -1,0 +1,39 @@
+-- Verification script: confirms cash/net_worth are blocked from direct client writes.
+-- Run this after applying the migration against a test database.
+
+-- 1. Create a test user and profile
+INSERT INTO auth.users (id, email, aud, role, raw_app_meta_data, raw_user_meta_data, created_at, updated_at)
+VALUES ('00000000-0000-0000-0000-000000000001', 'test@example.com', 'authenticated', 'authenticated', '{}', '{}', now(), now())
+ON CONFLICT DO NOTHING;
+
+INSERT INTO user_profiles (id, name, cash, net_worth)
+VALUES ('00000000-0000-0000-0000-000000000001', 'Test User', 100.00, 100.00)
+ON CONFLICT (id) DO UPDATE SET cash = 100.00, net_worth = 100.00;
+
+-- 2. As the authenticated role, try to update cash directly
+-- This should FAIL with a policy violation error.
+SET role = 'authenticated';
+SET request.jwt.claims = '{"sub": "00000000-0000-0000-0000-000000000001"}';
+
+DO $$
+BEGIN
+    UPDATE user_profiles SET cash = 999999 WHERE id = '00000000-0000-0000-0000-000000000001';
+    RAISE EXCEPTION 'TEST FAILED: Direct cash update should have been blocked';
+EXCEPTION WHEN check_violation THEN
+    RAISE NOTICE 'TEST PASSED: Direct cash update correctly blocked by RLS WITH CHECK';
+END $$;
+
+-- 3. Verify safe columns (name, avatar_url) still work
+BEGIN
+    UPDATE user_profiles SET name = 'Updated Name' WHERE id = '00000000-0000-0000-0000-000000000001';
+    RAISE NOTICE 'TEST PASSED: Name update still works';
+EXCEPTION WHEN OTHERS THEN
+    RAISE EXCEPTION 'TEST FAILED: Name update should not be blocked: %', SQLERRM;
+END;
+
+-- Reset role
+RESET role;
+
+-- Cleanup
+DELETE FROM user_profiles WHERE id = '00000000-0000-0000-0000-000000000001';
+DELETE FROM auth.users WHERE id = '00000000-0000-0000-0000-000000000001';


### PR DESCRIPTION
## Summary

The UPDATE policy on `user_profiles` only checks row ownership (`auth.uid() = id`) with no column restriction. Any authenticated user can bypass the app entirely and set arbitrary `cash`/`net_worth` values via the Supabase JS client from devtools.

## Fix

Adds a `WITH CHECK` clause that preserves `OLD.cash` and `OLD.net_worth` values on direct client writes:

```sql
CREATE POLICY "Users can update own profile" ON user_profiles
  FOR UPDATE
  USING (auth.uid() = id)
  WITH CHECK (
    auth.uid() = id
    AND cash IS NOT DISTINCT FROM OLD.cash
    AND net_worth IS NOT DISTINCT FROM OLD.net_worth
  );
```

This follows the same pattern as the `update_username()` migration (20260813010000), which locked down the `name` column behind a validated RPC.

## Why this is safe

All legitimate `cash`/`net_worth` mutations already go through SECURITY DEFINER RPCs that bypass RLS:
- `purchase_stock_shares()` — deducts cash on stock purchase
- `process_habit_completion_dividends()` — credits dividends to cash
- `business_deletion` trigger — refunds stockholders
- `recalculate_net_worth()` — recomputes from scratch

None of these are affected by the RLS change.

## Verification

Includes `supabase/verify_cash_rls_fix.sql` which confirms:
1. Direct `cash` update is blocked (CHECK violation)
2. Safe columns like `name` still work

Fixes #25
