### PR TITLE
Add clickable Today's Stock Dividends popup with live per-business status

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -128,9 +128,8 @@
         </ion-card>
 
         <ion-card
-          class="stat-card"
-          [class.clickable-card]="isStatAbbreviated(todaysStockEarnings)"
-          (click)="showExactStatValue('Today\'s Stock Dividends', todaysStockEarnings, true)"
+          class="stat-card clickable-card"
+          (click)="openTodaysDividendsModal()"
         >
           <ion-card-content>
             <div class="stat-content">

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -6,7 +6,7 @@ import { Subscription } from 'rxjs';
 import {
   IonHeader, IonToolbar, IonTitle, IonButtons, IonContent, IonCard, IonCardContent,
   IonCardHeader, IonCardTitle, IonGrid, IonRow, IonCol, IonButton, IonIcon,
-  IonList, IonItem, IonLabel, IonBadge, IonInput, IonSkeletonText, ToastController, AlertController
+  IonList, IonItem, IonLabel, IonBadge, IonInput, IonSkeletonText, ToastController, AlertController, ModalController
 } from '@ionic/angular/standalone';
 import { AuthService } from '../services/auth.service';
 import { AdminService } from '../services/admin.service';
@@ -18,6 +18,7 @@ import { HabitUpdateService } from '../services/habit-update.service';
 import { HabitIntervalService } from '../services/habit-interval.service';
 import { BottomNavComponent } from '../shared/bottom-nav/bottom-nav.component';
 import { HabitCardComponent } from '../shared/components/habit-card/habit-card.component';
+import { TodaysDividendsModalComponent } from '../shared/components/todays-dividends-modal/todays-dividends-modal.component';
 import { formatLargeNumber } from '../shared/currency-format.util';
 import { addIcons } from 'ionicons';
 import { alertCircle, refresh, construct, addCircle, business, calendar, calendarOutline, time, ellipseOutline, add, lockClosed, logIn, trendingUpOutline, wallet, cash, logoUsd, settings, helpCircle, close, analytics, shield } from 'ionicons/icons';
@@ -83,7 +84,8 @@ export class HomePage implements OnInit, OnDestroy {
     private habitIntervalService: HabitIntervalService,
     private offlineQueueService: OfflineQueueService,
     private habitCacheService: HabitCacheService,
-    private jointVentureService: JointVentureService
+    private jointVentureService: JointVentureService,
+    private modalController: ModalController
   ) {
     addIcons({ alertCircle, refresh, construct, addCircle, business, calendar, calendarOutline, time, ellipseOutline, add, lockClosed, logIn, trendingUpOutline, wallet, cash, logoUsd, settings, helpCircle, close, analytics, shield });
     this.setRandomTagline();
@@ -491,6 +493,27 @@ export class HomePage implements OnInit, OnDestroy {
       return this.abbreviateStatNumber(value);
     }
     return value.toLocaleString('en-US');
+  }
+
+  /**
+   * Open the "Today's Stock Dividends" breakdown: every stock this user
+   * holds, who owns/runs each business, the estimated dividend per
+   * completion, and whether that business has completed its habit today.
+   * The modal fetches and periodically re-fetches its own data (see
+   * TodaysDividendsModalComponent) so it stays live while open.
+   */
+  async openTodaysDividendsModal() {
+    if (!this.currentUser) return;
+    const modal = await this.modalController.create({
+      component: TodaysDividendsModalComponent,
+      componentProps: {
+        modalController: this.modalController,
+        userId: this.currentUser.id,
+        todaysStockEarnings: this.todaysStockEarnings
+      },
+      cssClass: 'todays-dividends-modal'
+    });
+    await modal.present();
   }
 
   /**

--- a/src/app/services/habit-business.service.ts
+++ b/src/app/services/habit-business.service.ts
@@ -117,6 +117,24 @@ export interface StockHolding {
   };
 }
 
+/** One stock holding's dividend status, as shown in the home screen's
+ *  "Today's Stock Dividends" popup — see get_todays_dividend_status. */
+export interface DividendStatusItem {
+  holdingId: string;
+  stockId: string;
+  businessId: string;
+  businessName: string;
+  businessIcon: string;
+  ownerId: string;
+  ownerName: string;
+  isJointVenture: boolean;
+  coOwnerCount: number;
+  sharesOwned: number;
+  dividendPerCompletion: number;
+  completedToday: boolean;
+  isActiveToday: boolean;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -1775,6 +1793,49 @@ export class HabitBusinessService {
     } catch (error) {
       console.error('Error in getTodaysStockDividends:', error);
       throw error;
+    }
+  }
+
+  /**
+   * Per-business breakdown behind the "Today's Stock Dividends" home screen
+   * stat: every stock this user holds, who owns/runs the business, the
+   * estimated dividend per completion for this holding, and whether that
+   * business has completed its habit today. Backed by get_todays_dividend_status,
+   * which reads completion status off habit_completions directly (not
+   * current_progress) so it stays accurate even for a business whose owner
+   * hasn't opened the app today.
+   */
+  async getTodaysDividendStatus(userId: string): Promise<DividendStatusItem[]> {
+    try {
+      const clientTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      const { data, error } = await this.supabase.rpc('get_todays_dividend_status', {
+        user_uuid: userId,
+        p_client_timezone: clientTimezone
+      });
+
+      if (error) {
+        console.error('Error fetching today\'s dividend status:', error);
+        throw error;
+      }
+
+      return (data || []).map((row: any) => ({
+        holdingId: row.holding_id,
+        stockId: row.stock_id,
+        businessId: row.business_id,
+        businessName: row.business_name,
+        businessIcon: row.business_icon,
+        ownerId: row.owner_id,
+        ownerName: row.owner_name,
+        isJointVenture: row.is_joint_venture,
+        coOwnerCount: row.co_owner_count || 0,
+        sharesOwned: row.shares_owned,
+        dividendPerCompletion: row.dividend_per_completion,
+        completedToday: row.completed_today,
+        isActiveToday: row.is_active_today
+      }));
+    } catch (error) {
+      console.error('Error in getTodaysDividendStatus:', error);
+      return [];
     }
   }
 

--- a/src/app/shared/components/todays-dividends-modal/todays-dividends-modal.component.html
+++ b/src/app/shared/components/todays-dividends-modal/todays-dividends-modal.component.html
@@ -1,0 +1,89 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>
+      <div class="modal-title">
+        <ion-icon name="trending-up" color="success"></ion-icon>
+        Today's Stock Dividends
+      </div>
+    </ion-title>
+    <ion-buttons slot="end">
+      <ion-button fill="clear" (click)="manualRefresh()" [disabled]="isRefreshing" class="refresh-btn">
+        <ion-icon name="refresh" [class.spinning]="isRefreshing"></ion-icon>
+      </ion-button>
+      <ion-button fill="clear" (click)="dismiss()">
+        <ion-icon name="close"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="dividends-modal-content">
+  <div *ngIf="isLoading" class="loading-state">
+    <ion-spinner name="crescent"></ion-spinner>
+  </div>
+
+  <ng-container *ngIf="!isLoading">
+    <div class="hero-card">
+      <div class="hero-label">Received Today</div>
+      <div class="hero-value">${{ fmt(todaysStockEarnings) }}</div>
+      <div class="hero-sub" *ngIf="items.length > 0">
+        {{ completedCount }} of {{ items.length }} businesses have paid out today
+      </div>
+    </div>
+
+    <div *ngIf="items.length === 0" class="empty-state">
+      <ion-icon name="trending-up" color="medium"></ion-icon>
+      <h3>No stock holdings yet</h3>
+      <p>Buy shares in a friend's business from the Stocks tab to start earning dividends whenever they complete their habit.</p>
+    </div>
+
+    <div *ngIf="items.length > 0" class="holdings-list">
+      <div
+        class="holding-row"
+        *ngFor="let item of items; trackBy: trackByHoldingId"
+        [class.is-completed]="statusFor(item) === 'completed'"
+        [class.is-resting]="statusFor(item) === 'resting'"
+        [class.is-pending]="statusFor(item) === 'pending'"
+      >
+        <img
+          *ngIf="item.businessIcon | businessIconSrc as iconSrc"
+          [src]="iconSrc"
+          [alt]="item.businessName"
+          class="business-icon-img"
+        />
+        <div *ngIf="!(item.businessIcon | businessIconSrc)" class="business-icon-emoji">
+          {{ item.businessIcon || '📈' }}
+        </div>
+
+        <div class="holding-info">
+          <div class="holding-name">{{ item.businessName }}</div>
+          <div class="holding-owner">Owned by {{ ownerLabel(item) }}</div>
+          <div class="holding-shares">{{ item.sharesOwned }} {{ item.sharesOwned === 1 ? 'share' : 'shares' }}</div>
+        </div>
+
+        <div class="holding-right">
+          <div class="holding-amount">${{ fmt(item.dividendPerCompletion) }}</div>
+          <div class="status-pill" [ngSwitch]="statusFor(item)">
+            <ng-container *ngSwitchCase="'completed'">
+              <ion-icon name="checkmark-circle"></ion-icon>
+              <span>Completed</span>
+            </ng-container>
+            <ng-container *ngSwitchCase="'resting'">
+              <ion-icon name="moon-outline"></ion-icon>
+              <span>Resting Today</span>
+            </ng-container>
+            <ng-container *ngSwitchCase="'pending'">
+              <ion-icon name="time-outline"></ion-icon>
+              <span>Not Yet Completed</span>
+            </ng-container>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="live-note">
+      <span class="live-dot"></span>
+      Updates automatically every minute &mdash; last refreshed {{ lastUpdatedAt | date:'shortTime' }}
+    </div>
+  </ng-container>
+</ion-content>

--- a/src/app/shared/components/todays-dividends-modal/todays-dividends-modal.component.scss
+++ b/src/app/shared/components/todays-dividends-modal/todays-dividends-modal.component.scss
@@ -1,0 +1,242 @@
+.modal-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.refresh-btn ion-icon {
+  transition: transform 0.2s ease;
+
+  &.spinning {
+    animation: spin 0.9s linear infinite;
+  }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.dividends-modal-content {
+  --background: var(--ion-color-light);
+  --padding-start: 16px;
+  --padding-end: 16px;
+  --padding-top: 12px;
+  --padding-bottom: 16px;
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 48px 0;
+}
+
+.hero-card {
+  background: var(--business-item-background);
+  border: 1px solid rgba(var(--ion-color-success-rgb), 0.35);
+  border-radius: 16px;
+  padding: 18px 16px;
+  text-align: center;
+  margin-bottom: 18px;
+  box-shadow: 0 0 0 1px rgba(var(--ion-color-success-rgb), 0.12) inset;
+}
+
+.hero-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.55);
+  margin-bottom: 4px;
+}
+
+.hero-value {
+  font-size: 32px;
+  font-weight: 800;
+  color: var(--ion-color-success);
+  line-height: 1.15;
+}
+
+.hero-sub {
+  margin-top: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 32px 20px;
+  color: rgba(255, 255, 255, 0.6);
+
+  ion-icon {
+    font-size: 40px;
+    margin-bottom: 8px;
+  }
+
+  h3 {
+    color: #ffffff;
+    font-size: 16px;
+    font-weight: 600;
+    margin: 4px 0;
+  }
+
+  p {
+    font-size: 13.5px;
+    line-height: 1.4;
+    max-width: 320px;
+    margin: 0 auto;
+  }
+}
+
+.holdings-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.holding-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--business-item-background);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-left: 3px solid transparent;
+  border-radius: 12px;
+  padding: 12px 14px;
+
+  &.is-completed {
+    border-left-color: var(--ion-color-success);
+  }
+
+  &.is-pending {
+    border-left-color: var(--ion-color-warning);
+  }
+
+  &.is-resting {
+    border-left-color: rgba(255, 255, 255, 0.25);
+    opacity: 0.85;
+  }
+}
+
+.business-icon-img {
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  border-radius: 22%;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}
+
+.business-icon-emoji {
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  font-size: 28px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.holding-info {
+  min-width: 0;
+  flex: 1;
+}
+
+.holding-name {
+  font-weight: 700;
+  color: #ffffff;
+  font-size: 14.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.holding-owner {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.55);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 1px;
+}
+
+.holding-shares {
+  font-size: 11.5px;
+  color: rgba(255, 255, 255, 0.4);
+  margin-top: 1px;
+}
+
+.holding-right {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
+}
+
+.holding-amount {
+  font-weight: 700;
+  font-size: 15px;
+  color: #ffffff;
+  white-space: nowrap;
+}
+
+.status-pill {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+  padding: 3px 8px;
+  border-radius: 20px;
+
+  ion-icon {
+    font-size: 12px;
+  }
+}
+
+.is-completed .status-pill {
+  color: var(--ion-color-success);
+  background: rgba(var(--ion-color-success-rgb), 0.14);
+}
+
+.is-pending .status-pill {
+  color: var(--ion-color-warning);
+  background: rgba(var(--ion-color-warning-rgb), 0.14);
+}
+
+.is-resting .status-pill {
+  color: rgba(255, 255, 255, 0.55);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.live-note {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 16px;
+  font-size: 11.5px;
+  color: rgba(255, 255, 255, 0.4);
+  text-align: center;
+}
+
+.live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ion-color-success);
+  box-shadow: 0 0 0 0 rgba(var(--ion-color-success-rgb), 0.5);
+  animation: pulse 2s infinite;
+  flex-shrink: 0;
+}
+
+@keyframes pulse {
+  0% { box-shadow: 0 0 0 0 rgba(var(--ion-color-success-rgb), 0.5); }
+  70% { box-shadow: 0 0 0 5px rgba(var(--ion-color-success-rgb), 0); }
+  100% { box-shadow: 0 0 0 0 rgba(var(--ion-color-success-rgb), 0); }
+}

--- a/src/app/shared/components/todays-dividends-modal/todays-dividends-modal.component.ts
+++ b/src/app/shared/components/todays-dividends-modal/todays-dividends-modal.component.ts
@@ -1,0 +1,113 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  IonHeader, IonToolbar, IonTitle, IonContent, IonButton, IonIcon,
+  IonButtons, IonSpinner
+} from '@ionic/angular/standalone';
+import { HabitBusinessService, DividendStatusItem } from '../../../services/habit-business.service';
+import { BusinessIconPipe } from '../../pipes/business-icon.pipe';
+import { addIcons } from 'ionicons';
+import { trendingUp, close, checkmarkCircle, timeOutline, moonOutline, refresh } from 'ionicons/icons';
+
+/** How often to silently re-fetch while the modal stays open, so a co-owner
+ *  checking in elsewhere (or the backend reconciliation sweep — see
+ *  reconcile_missed_stock_dividends in
+ *  20260825050000_todays_dividend_status_and_reconciliation.sql) shows up
+ *  here without the user having to close and reopen the popup. */
+const REFRESH_INTERVAL_MS = 60_000;
+
+@Component({
+  selector: 'app-todays-dividends-modal',
+  templateUrl: './todays-dividends-modal.component.html',
+  styleUrls: ['./todays-dividends-modal.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule, IonHeader, IonToolbar, IonTitle, IonContent, IonButton,
+    IonIcon, IonButtons, IonSpinner, BusinessIconPipe
+  ]
+})
+export class TodaysDividendsModalComponent implements OnInit, OnDestroy {
+  @Input() userId: string = '';
+  /** Exact "already received today" total from the home screen stat card
+   *  the user tapped — shown as the hero figure so the popup's headline
+   *  number always matches what they clicked on. */
+  @Input() todaysStockEarnings: number = 0;
+  @Input() modalController: any;
+
+  items: DividendStatusItem[] = [];
+  isLoading = true;
+  isRefreshing = false;
+  lastUpdatedAt = new Date();
+  private refreshIntervalId: any;
+
+  constructor(private habitBusinessService: HabitBusinessService) {
+    addIcons({ trendingUp, close, checkmarkCircle, timeOutline, moonOutline, refresh });
+  }
+
+  async ngOnInit() {
+    await this.load();
+    this.refreshIntervalId = setInterval(() => this.load(true), REFRESH_INTERVAL_MS);
+  }
+
+  ngOnDestroy() {
+    if (this.refreshIntervalId) {
+      clearInterval(this.refreshIntervalId);
+    }
+  }
+
+  private async load(silent: boolean = false) {
+    if (!this.userId) {
+      this.isLoading = false;
+      return;
+    }
+    if (silent) {
+      this.isRefreshing = true;
+    }
+    try {
+      this.items = await this.habitBusinessService.getTodaysDividendStatus(this.userId);
+      this.lastUpdatedAt = new Date();
+    } finally {
+      this.isLoading = false;
+      this.isRefreshing = false;
+    }
+  }
+
+  async manualRefresh() {
+    if (this.isRefreshing) return;
+    await this.load(true);
+  }
+
+  /** UI status for a row: 'completed' (checkmark), 'resting' (nothing due
+   *  today, shown before "not yet completed" so a rest-day business doesn't
+   *  read as behind), or 'pending' (not yet completed, due today). */
+  statusFor(item: DividendStatusItem): 'completed' | 'resting' | 'pending' {
+    if (item.completedToday) return 'completed';
+    if (!item.isActiveToday) return 'resting';
+    return 'pending';
+  }
+
+  /** "Owned by X" for a single owner, "Owned by X & N others" for a joint venture. */
+  ownerLabel(item: DividendStatusItem): string {
+    const others = (item.coOwnerCount || 1) - 1;
+    if (item.isJointVenture && others > 0) {
+      return `${item.ownerName} & ${others} other${others === 1 ? '' : 's'}`;
+    }
+    return item.ownerName;
+  }
+
+  get completedCount(): number {
+    return this.items.filter(i => i.completedToday).length;
+  }
+
+  fmt(n: number | undefined): string {
+    return Math.abs(n || 0).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+
+  trackByHoldingId(_index: number, item: DividendStatusItem): string {
+    return item.holdingId;
+  }
+
+  dismiss() {
+    this.modalController.dismiss();
+  }
+}

--- a/src/global.scss
+++ b/src/global.scss
@@ -228,6 +228,20 @@
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 }
 
+/* Today's Stock Dividends Modal (home screen stat card) */
+.todays-dividends-modal .modal-wrapper {
+  --height: auto;
+  --max-height: 85%;
+  --max-width: 460px;
+  --width: 92%;
+  --border-radius: 20px;
+}
+
+.todays-dividends-modal .modal-wrapper .modal-shadow {
+  border-radius: 20px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
 /* Custom Alert Styles */
 .alert-wrapper {
   --max-width: 400px;

--- a/supabase/migrations/20260825050000_todays_dividend_status_and_reconciliation.sql
+++ b/supabase/migrations/20260825050000_todays_dividend_status_and_reconciliation.sql
@@ -1,0 +1,173 @@
+-- Home screen "Today's Stock Dividends" popup — per-business dividend status
+-- for every stock the calling user holds, plus a scheduled backend
+-- reconciliation job that repairs any dividend that silently failed to pay.
+--
+-- 1. get_todays_dividend_status(): one row per stock holding — business
+--    identity, who owns/runs it, this holder's per-completion dividend
+--    estimate (same formula as get_user_stock_portfolio's daily_dividend_rate
+--    — see 20260820170000_fix_portfolio_daily_dividend_rate_formula.sql), and
+--    whether that business has completed its habit today. "Completed today"
+--    is read off habit_completions directly (an append-only, authoritative
+--    record) rather than habit_businesses.current_progress/last_completed_at
+--    — those columns are only rolled over lazily by reset_outdated_habits()
+--    when *that business's own owner* opens the app (see
+--    20260817010000_fix_reset_outdated_habits_timezone.sql), so for a
+--    business some *other* user (a stockholder) is looking at, they can sit
+--    stale showing yesterday's completion. habit_completions has no such
+--    staleness. This also sidesteps needing to special-case joint ventures
+--    (whose per-owner current_progress/goal_value aren't meaningful at all —
+--    see complete_joint_venture_checkin in
+--    20260820180000_jv_per_checkin_dividends_and_group_bonus.sql): "at least
+--    one completion recorded today" is well-defined either way.
+--
+-- 2. reconcile_missed_stock_dividends(): complete_habit_business,
+--    complete_habit_business_yesterday and complete_joint_venture_checkin all
+--    wrap their process_habit_completion_dividends() call in
+--    `EXCEPTION WHEN OTHERS` (see 20260824010000_log_dividend_processing_errors.sql
+--    for the warning-log half of that) so a dividend bug never blocks the
+--    habit completion itself — but that also means a transient failure
+--    leaves a completion with no dividend_payments row, permanently, with
+--    nothing to retry it. This sweeps every completion from the last 48h for
+--    a stocked business that has real stockholders and no dividend_payments
+--    row yet, and retries it. Scheduled via pg_cron every minute — same
+--    mechanism as expire_joint_venture_notifications
+--    (20260825010000_scheduled_joint_venture_expiry.sql) and
+--    sync_all_stock_prices (20260811020000_fix_ramp_compounding_and_hourly_sync.sql)
+--    — so the dividend status this popup shows (and the cash it's paid out)
+--    stays accurate on its own, without depending on anyone reopening the
+--    app. dividend_payments.habit_completion_id is UNIQUE, so a completion
+--    already paid is never retried or double-paid.
+
+CREATE OR REPLACE FUNCTION get_todays_dividend_status(
+    user_uuid UUID,
+    p_client_timezone TEXT DEFAULT 'UTC'
+) RETURNS TABLE (
+    holding_id UUID,
+    stock_id UUID,
+    business_id UUID,
+    business_name TEXT,
+    business_icon TEXT,
+    owner_id UUID,
+    owner_name TEXT,
+    is_joint_venture BOOLEAN,
+    co_owner_count INTEGER,
+    shares_owned INTEGER,
+    dividend_per_completion NUMERIC,
+    completed_today BOOLEAN,
+    is_active_today BOOLEAN
+) LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+    v_period_start TIMESTAMPTZ := date_trunc('day', NOW() AT TIME ZONE p_client_timezone) AT TIME ZONE p_client_timezone;
+    v_dow INTEGER := EXTRACT(DOW FROM NOW() AT TIME ZONE p_client_timezone)::INTEGER;
+BEGIN
+    RETURN QUERY
+    SELECT
+        sh.id AS holding_id,
+        bs.id AS stock_id,
+        hb.id AS business_id,
+        bt.name AS business_name,
+        -- Public business type name/icon, never the private per-habit name/icon
+        -- (same privacy rule as get_user_stock_portfolio and get_friend_businesses_for_stocks).
+        bt.icon AS business_icon,
+        hb.user_id AS owner_id,
+        up.name AS owner_name,
+        hb.is_joint_venture,
+        COALESCE(co.n, 0)::INTEGER AS co_owner_count,
+        sh.shares_owned,
+        -- Same base + stock-boost + streak-bonus math as complete_habit_business's
+        -- v_total_earnings, split across total_shares_issued and scaled to this
+        -- holding's shares — identical formula to get_user_stock_portfolio's
+        -- daily_dividend_rate. Minimum $0.01 per completion regardless of holding size.
+        GREATEST(
+            ROUND(
+                (
+                    (
+                        hb.earnings_per_completion + hb.earnings_per_completion * (
+                            GREATEST(
+                                0,
+                                (COALESCE(bs.total_shares_issued, 100) - COALESCE(bs.shares_owned_by_owner, 100)) - COALESCE(bs.shares_available, 0)
+                            )::NUMERIC / 100
+                        )
+                    ) * (
+                        1 + CASE WHEN hb.streak > 0 THEN LEAST(hb.streak * 0.1, 1) ELSE 0 END
+                    )
+                ) * sh.shares_owned::NUMERIC / COALESCE(NULLIF(bs.total_shares_issued, 0), 100)::NUMERIC,
+                2
+            ),
+            0.01
+        ) AS dividend_per_completion,
+        EXISTS (
+            SELECT 1 FROM habit_completions hc
+            WHERE hc.habit_business_id = hb.id AND hc.completed_at >= v_period_start
+        ) AS completed_today,
+        -- CASE (not a bare boolean expression) so a NULL hb.frequency doesn't
+        -- propagate NULL through the OR/AND below — CASE WHEN treats a NULL
+        -- condition as non-matching and falls through to ELSE true, the same
+        -- way habit-interval.service.ts's resolveInterval (and this same
+        -- recurrence_interval/frequency check in complete_habit_business)
+        -- treats a '24h' habit with no frequency set as always active.
+        CASE
+            WHEN (hb.recurrence_interval IN ('specific_days', '7d') OR hb.frequency = 'weekly')
+                THEN (v_dow = ANY(COALESCE(hb.active_days, ARRAY[]::INTEGER[])))
+            ELSE true
+        END AS is_active_today
+    FROM stock_holdings sh
+        INNER JOIN business_stocks bs ON sh.stock_id = bs.id
+        INNER JOIN habit_businesses hb ON bs.habit_business_id = hb.id
+        INNER JOIN business_types bt ON hb.business_type_id = bt.id
+        INNER JOIN user_profiles up ON hb.user_id = up.id
+        LEFT JOIN (
+            SELECT habit_business_id, COUNT(*) AS n FROM business_co_owners GROUP BY habit_business_id
+        ) co ON co.habit_business_id = hb.id
+    WHERE sh.holder_id = user_uuid
+        AND sh.shares_owned > 0
+        AND hb.is_active = true
+    ORDER BY completed_today ASC, bt.name ASC;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION get_todays_dividend_status(UUID, TEXT) TO authenticated;
+
+CREATE OR REPLACE FUNCTION reconcile_missed_stock_dividends() RETURNS INTEGER
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+    v_completion RECORD;
+    v_reconciled_count INTEGER := 0;
+BEGIN
+    FOR v_completion IN
+        SELECT hc.id
+        FROM habit_completions hc
+            INNER JOIN habit_businesses hb ON hb.id = hc.habit_business_id
+            INNER JOIN business_stocks bs ON bs.habit_business_id = hb.id
+        WHERE hc.completed_at >= NOW() - INTERVAL '48 hours'
+            AND NOT EXISTS (
+                SELECT 1 FROM dividend_payments dp WHERE dp.habit_completion_id = hc.id
+            )
+            AND EXISTS (
+                SELECT 1 FROM stock_holdings sh WHERE sh.stock_id = bs.id AND sh.shares_owned > 0
+            )
+    LOOP
+        BEGIN
+            PERFORM process_habit_completion_dividends(v_completion.id);
+            v_reconciled_count := v_reconciled_count + 1;
+        EXCEPTION WHEN OTHERS THEN
+            RAISE WARNING 'reconcile_missed_stock_dividends: failed for completion %: %', v_completion.id, SQLERRM;
+        END;
+    END LOOP;
+
+    RETURN v_reconciled_count;
+END;
+$$;
+COMMENT ON FUNCTION reconcile_missed_stock_dividends() IS 'Scheduled via pg_cron (reconcile-missed-stock-dividends-1min) every minute. Safety net for the EXCEPTION WHEN OTHERS around every process_habit_completion_dividends call site (complete_habit_business, complete_habit_business_yesterday, complete_joint_venture_checkin) — finds any completion in the last 48h for a stocked business with real stockholders that never produced a dividend_payments row, and retries it, so stockholder cash and the Today''s Stock Dividends popup stay accurate without depending on any user reopening the app. Deliberately never GRANTed to authenticated/anon — backend job only, not callable from the client.';
+
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'reconcile-missed-stock-dividends-1min') THEN
+        PERFORM cron.unschedule('reconcile-missed-stock-dividends-1min');
+    END IF;
+END $$;
+
+SELECT cron.schedule('reconcile-missed-stock-dividends-1min', '* * * * *', $$SELECT public.reconcile_missed_stock_dividends();$$);
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- Tapping the home screen's "Today's Stock Dividends" card now opens a popup listing every business the user owns stock in: who owns/runs it, the estimated dividend per completion, and a checkmark / "Not Yet Completed" / "Resting Today" status for whether that business's habit has been done today.
- The popup re-fetches every 60 seconds while open, on top of a new `get_todays_dividend_status()` RPC that reads completion status off `habit_completions` directly (not the mutable `current_progress` column) so it stays accurate for businesses whose owner hasn't opened the app today.
- Added `reconcile_missed_stock_dividends()`, a `pg_cron` job scheduled every minute, that retries any habit completion whose dividend payout silently failed (the existing dividend-processing calls swallow errors) — keeping stockholder payouts and the popup's data self-healing.

## Test plan
- [x] `ng build --configuration production` succeeds with no new errors/warnings
- [x] Both new SQL functions validated against a real local Postgres instance with a stub schema + seeded data: confirmed `completed_today`/`is_active_today` correctness across a completed daily habit, a pending `specific_days` habit, a resting (no active days) habit, and a joint venture; confirmed `reconcile_missed_stock_dividends()` finds and repairs a completion with a missing `dividend_payments` row, pays the stockholder correctly, and is idempotent on a second run
- [x] Fixed a NULL-propagation bug in `is_active_today` (a `NULL` `frequency` column made the boolean expression evaluate to `NULL` instead of `true`) that was only caught by this DB-level testing


---
_Generated by [Claude Code](https://claude.ai/code/session_018vZKN3dBpnNw1HrpMuLTd1)_